### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Major-Updates sollten wir wahrscheinlich immer manuell machen - meldet euch gerne hier, wenn ihr das anders seht

Aktueller Anlass: https://github.com/freenet-actions/setup-jq/pull/564